### PR TITLE
Fix lib directory not being build/installed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,7 @@ ERL_SRC.each do |input|
 end
 
 REIA_SRC  = FileList.new('src/{builtins,core}/**/*.re')
+REIA_SRC.include('lib/*.re')
 REIA_DEST = REIA_SRC.map { |input| output_file(input, 'ebin/', '.reb') }
 
 REIA_SRC.each do |input|


### PR DESCRIPTION
This patch corrects the lib directory not being included in the REIA_SRC filelist and thus not having it's .reb files copied to the ebin/ directory for installation.
